### PR TITLE
setting: 빈 화면들 및 이동 로직 추가

### DIFF
--- a/ody_flutter/lib/main.dart
+++ b/ody_flutter/lib/main.dart
@@ -1,4 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:ody_flutter/screens/eta_board_screen.dart';
+import 'package:ody_flutter/screens/gathering_creator_screen.dart';
+import 'package:ody_flutter/screens/invitation_code_screen.dart';
+import 'package:ody_flutter/screens/status_board_screen.dart';
+
+import 'screens/login_screen.dart';
+import 'screens/gatherings_screen.dart';
+import 'screens/settings_screen.dart';
+import 'screens/splash_screen.dart';
 
 void main() {
   runApp(const MyApp());
@@ -10,11 +19,23 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      debugShowCheckedModeBanner: false,
       title: 'Ody',
       theme: ThemeData(
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.deepPurple),
         useMaterial3: true,
       ),
+      initialRoute: '/splash',
+      routes: {
+        '/splash': (context) => const SplashScreen(),
+        '/login': (context) => const LoginScreen(),
+        '/gatherings': (context) => const GatheringsScreen(),
+        '/gatheringCreation': (context) => const GatheringCreatorScreen(),
+        '/settings': (context) => const SettingsScreen(),
+        '/invitationCode': (context) => const InvitationCodeScreen(),
+        '/etaBoard': (context) => const EtaBoardScreen(),
+        '/statusBoard': (context) => const StatusBoardScreen(),
+      },
     );
   }
 }

--- a/ody_flutter/lib/screens/eta_board_screen.dart
+++ b/ody_flutter/lib/screens/eta_board_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class EtaBoardScreen extends StatefulWidget {
+  const EtaBoardScreen({super.key});
+
+  @override
+  State<EtaBoardScreen> createState() => _EtaBoardScreenState();
+}
+
+class _EtaBoardScreenState extends State<EtaBoardScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: Text('친구 위치 현황표 화면'));
+  }
+}

--- a/ody_flutter/lib/screens/gathering_creator_screen.dart
+++ b/ody_flutter/lib/screens/gathering_creator_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class GatheringCreatorScreen extends StatefulWidget {
+  const GatheringCreatorScreen({super.key});
+
+  @override
+  State<GatheringCreatorScreen> createState() => _GatheringCreatorScreenState();
+}
+
+class _GatheringCreatorScreenState extends State<GatheringCreatorScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: Text('약속 생성 화면'));
+  }
+}

--- a/ody_flutter/lib/screens/gatherings_screen.dart
+++ b/ody_flutter/lib/screens/gatherings_screen.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+
+class GatheringsScreen extends StatefulWidget {
+  const GatheringsScreen({super.key});
+
+  @override
+  State<GatheringsScreen> createState() => _GatheringsScreenState();
+}
+
+class _GatheringsScreenState extends State<GatheringsScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          ElevatedButton(
+            onPressed: () {
+              Navigator.pushNamed(context, '/settings');
+            },
+            child: const Text('설정'),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.pushNamed(context, '/gatheringCreation');
+            },
+            child: const Text('약속 생성'),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.pushNamed(context, '/invitationCode');
+            },
+            child: const Text('초대 코드'),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.pushNamed(context, '/etaBoard');
+            },
+            child: const Text('친구 현황표'),
+          ),
+          ElevatedButton(
+            onPressed: () {
+              Navigator.pushNamed(context, '/statusBoard');
+            },
+            child: const Text('상태 현황표'),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/ody_flutter/lib/screens/invitation_code_screen.dart
+++ b/ody_flutter/lib/screens/invitation_code_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class InvitationCodeScreen extends StatefulWidget {
+  const InvitationCodeScreen({super.key});
+
+  @override
+  State<InvitationCodeScreen> createState() => _InvitationCodeScreenState();
+}
+
+class _InvitationCodeScreenState extends State<InvitationCodeScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: Text('초대 코드 화면'));
+  }
+}

--- a/ody_flutter/lib/screens/login_screen.dart
+++ b/ody_flutter/lib/screens/login_screen.dart
@@ -1,0 +1,19 @@
+import 'package:flutter/material.dart';
+
+class LoginScreen extends StatelessWidget {
+  const LoginScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Center(
+        child: ElevatedButton(
+          onPressed: () {
+            Navigator.pushNamed(context, '/gatherings');
+          },
+          child: const Text('로그인'),
+        ),
+      ),
+    );
+  }
+}

--- a/ody_flutter/lib/screens/settings_screen.dart
+++ b/ody_flutter/lib/screens/settings_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class SettingsScreen extends StatefulWidget {
+  const SettingsScreen({super.key});
+
+  @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: Text('설정 화면'));
+  }
+}

--- a/ody_flutter/lib/screens/splash_screen.dart
+++ b/ody_flutter/lib/screens/splash_screen.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+class SplashScreen extends StatelessWidget {
+  const SplashScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    Future.delayed(const Duration(seconds: 2), () {
+      Navigator.pushReplacementNamed(context, '/login');
+    });
+
+    return const Scaffold(
+      body: Center(child: Text('스플래쉬 화면')),
+    );
+  }
+}

--- a/ody_flutter/lib/screens/status_board_screen.dart
+++ b/ody_flutter/lib/screens/status_board_screen.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+class StatusBoardScreen extends StatefulWidget {
+  const StatusBoardScreen({super.key});
+
+  @override
+  State<StatusBoardScreen> createState() => _StatusBoardScreenState();
+}
+
+class _StatusBoardScreenState extends State<StatusBoardScreen> {
+  @override
+  Widget build(BuildContext context) {
+    return const Center(child: Text('상태 현황표 화면'));
+  }
+}


### PR DESCRIPTION
## PR 요약
- Closed: #10 

## 작업 내용
개발하기 수월하고 머지 컨플릭트 빈도를 줄이기 위해 빈 화면들과 이동 로직을 설정했습니다.

## 참고 사항
어색한 네이밍이 있으면 말씀해주세요!

참여 완료 화면과 위치 현황 가이드 화면은 추후에 어떻게 개발될지 몰라 괜한 작업이라 생각해서 추가하지 않았습니다.

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->
