### PR TITLE
design: OdyButton 공통 컴포넌트 구현

### DIFF
--- a/ody_flutter/analysis_options.yaml
+++ b/ody_flutter/analysis_options.yaml
@@ -60,7 +60,7 @@ linter:
     - depend_on_referenced_packages
     - deprecated_consistency
     - deprecated_member_use_from_same_package
-    - diagnostic_describe_all_properties
+#    - diagnostic_describe_all_properties
     - directives_ordering
     - discarded_futures
     - do_not_use_environment
@@ -90,7 +90,7 @@ linter:
     - missing_code_block_language_in_doc_comment
     - missing_whitespace_between_adjacent_strings
     - no_adjacent_strings_in_list
-    - no_default_cases
+#    - no_default_cases
     - no_duplicate_case_values
     - no_leading_underscores_for_library_prefixes
     - no_leading_underscores_for_local_identifiers
@@ -126,7 +126,7 @@ linter:
     - prefer_final_fields
     - prefer_final_in_for_each
     - prefer_final_locals
-    - prefer_final_parameters
+#    - prefer_final_parameters
     - prefer_for_elements_to_map_fromIterable
     - prefer_foreach
     - prefer_function_declarations_over_variables

--- a/ody_flutter/lib/components/ody_button.dart
+++ b/ody_flutter/lib/components/ody_button.dart
@@ -1,0 +1,122 @@
+import "package:flutter/material.dart";
+import "package:flutter_svg/flutter_svg.dart";
+import "package:ody_flutter/assets/colors/colors.dart";
+
+enum OdyButtonType {
+  next,
+  ody,
+  confirm,
+}
+
+extension OdyButtonProperties on OdyButtonType {
+  String get title {
+    switch (this) {
+      case OdyButtonType.next:
+        return "다음";
+      case OdyButtonType.ody:
+        return "오디?";
+      case OdyButtonType.confirm:
+        return "확인";
+    }
+  }
+
+  Size get size {
+    switch (this) {
+      case OdyButtonType.next:
+        return const Size(360, 55);
+      case OdyButtonType.ody:
+        return const Size(86, 37);
+      case OdyButtonType.confirm:
+        return const Size(286, 45);
+    }
+  }
+
+  double get radius {
+    switch (this) {
+      case OdyButtonType.next:
+        return 0;
+      default:
+        return 10;
+    }
+  }
+
+  String get image {
+    switch (this) {
+      case OdyButtonType.ody:
+        return "assets/images/ic_ody.svg";
+      default:
+        return "";
+    }
+  }
+}
+
+class OdyButton extends StatefulWidget {
+  const OdyButton({
+    required this.buttonType,
+    required this.isEnabled,
+    this.onPressed,
+    super.key,
+  });
+
+  final OdyButtonType buttonType;
+  final VoidCallback? onPressed;
+  final ValueNotifier<bool> isEnabled;
+
+  @override
+  State<OdyButton> createState() => _OdyButtonState();
+}
+
+class _OdyButtonState extends State<OdyButton> {
+  @override
+  Widget build(BuildContext context) => ValueListenableBuilder<bool>(
+        valueListenable: widget.isEnabled,
+        builder: (_, isEnabled, __) => GestureDetector(
+          onTap: isEnabled ? widget.onPressed : null,
+          child: Container(
+            decoration: BoxDecoration(
+              color:
+                  isEnabled ? CommonColors.purple_800 : CommonColors.gray_350,
+              borderRadius: BorderRadius.circular(widget.buttonType.radius),
+            ),
+            width: widget.buttonType.size.width,
+            height: widget.buttonType.size.height,
+            child: (widget.buttonType.image.isNotEmpty)
+                ? _imgTextButton()
+                : _textButton(),
+          ),
+        ),
+      );
+
+  Widget _imgTextButton() => Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        spacing: 4,
+        children: [
+          SvgPicture.asset(
+            widget.buttonType.image,
+            colorFilter: const ColorFilter.mode(
+              CommonColors.white,
+              BlendMode.srcIn,
+            ),
+          ),
+          Text(
+            widget.buttonType.title,
+            style: const TextStyle(
+              fontFamily: "PretendardBold",
+              fontSize: 16,
+              color: CommonColors.white,
+            ),
+          ),
+        ],
+      );
+
+  Widget _textButton() => Center(
+        child: Text(
+          widget.buttonType.title,
+          style: const TextStyle(
+            fontFamily: "PretendardBold",
+            fontSize: 16,
+            color: CommonColors.white,
+          ),
+        ),
+      );
+}

--- a/ody_flutter/lib/components/ody_button.dart
+++ b/ody_flutter/lib/components/ody_button.dart
@@ -35,7 +35,8 @@ extension OdyButtonProperties on OdyButtonType {
     switch (this) {
       case OdyButtonType.next:
         return 0;
-      default:
+      case OdyButtonType.ody:
+      case OdyButtonType.confirm:
         return 10;
     }
   }
@@ -44,7 +45,8 @@ extension OdyButtonProperties on OdyButtonType {
     switch (this) {
       case OdyButtonType.ody:
         return "assets/images/ic_ody.svg";
-      default:
+      case OdyButtonType.next:
+      case OdyButtonType.confirm:
         return "";
     }
   }
@@ -53,13 +55,13 @@ extension OdyButtonProperties on OdyButtonType {
 class OdyButton extends StatefulWidget {
   const OdyButton({
     required this.buttonType,
+    required this.onPressed,
     required this.isEnabled,
-    this.onPressed,
     super.key,
   });
 
   final OdyButtonType buttonType;
-  final VoidCallback? onPressed;
+  final VoidCallback onPressed;
   final ValueNotifier<bool> isEnabled;
 
   @override


### PR DESCRIPTION
## PR 요약
- Closed: #20

## 작업 내용
OdyButton 공통 컴포넌트 구현했습니다.
아래 세 가지 케이스 버튼 추가했습니다.
- 다음
- 오디?
- 확인

## 참고 사항
#### OdyButton 생성자
```Dart
  const OdyButton({
    required this.buttonType,
    required this.isEnabled,
    this.onPressed,
    super.key,
  });
```
아래 두 변수는 필수로 전달해야 합니다.
- buttonType<OdyButtonType>: 어떤 버튼인지
  ```Dart
  enum OdyButtonType {
      next,
      ody,
      confirm,
  }
  ```
- isEnabled<ValueNotifier>: 활성화 상태인지 아닌지

#### OdyButton 사용 방법
```Dart
 final ValueNotifier<bool> isEnabled = ValueNotifier(true);

// build 내부
 child: OdyButton(
    buttonType: OdyButtonType.next,
    isEnabled: isEnabled,
    onPressed: () => debugPrint("오디 버튼 짱 b"),
 ),
```
isEnabled는 상태변화 관찰할 수 있는 ValueNotifier<bool> 타입 생성해서 전달해주세요 ~!

 ## 📸 스크린샷
|OdyButton Example|
|:--:|
|<img src="https://github.com/user-attachments/assets/d3c95a42-3b92-4f08-a144-d7d86487e89a" width=250>|
