### PR TITLE
bug: ci run test에서 .env 파일 못찾는 버그 수정

### DIFF
--- a/.github/workflows/flutter_ci.yml
+++ b/.github/workflows/flutter_ci.yml
@@ -26,10 +26,12 @@ jobs:
         run: |
           cd ody_flutter
           flutter analyze
-
+     
+      # Run Test에서는 .env 임의로 추가
       - name: Run test
         run: |
           cd ody_flutter
+          touch .env
           flutter test
           
       # Build iOS without code signing

--- a/ody_flutter/analysis_options.yaml
+++ b/ody_flutter/analysis_options.yaml
@@ -213,3 +213,6 @@ linter:
     - use_to_and_as_if_applicable
     - valid_regexps
     - void_checks
+analyzer:
+  errors:
+    asset_does_not_exist: ignore

--- a/ody_flutter/pubspec.yaml
+++ b/ody_flutter/pubspec.yaml
@@ -27,6 +27,7 @@ dev_dependencies:
 flutter:
   assets:
     - assets/images/
+    - .env
 
   fonts:
     - family: PretendardBold


### PR DESCRIPTION
## PR 요약
- Closed: #54 

## 작업 내용
run test에서는 .env 파일이 필요없기 때문에 ci에서 제외 시켰습니다.

## 참고 사항
없습니다.

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->
