### PR TITLE
feat: 개인 정보 처리 방침, 서비스 이용 약관 웹 뷰

### DIFF
--- a/ody_flutter/ios/Runner/Info.plist
+++ b/ody_flutter/ios/Runner/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
 	<key>CFBundleDevelopmentRegion</key>

--- a/ody_flutter/lib/screens/settings/settings_screen.dart
+++ b/ody_flutter/lib/screens/settings/settings_screen.dart
@@ -31,7 +31,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
   }
 
   @override
-  Widget build(BuildContext context) => Scaffold(
+  Widget build(final BuildContext context) => Scaffold(
         backgroundColor: CommonColors.cream,
         body: SafeArea(
           child: _showWebView

--- a/ody_flutter/lib/screens/settings/settings_screen.dart
+++ b/ody_flutter/lib/screens/settings/settings_screen.dart
@@ -6,6 +6,7 @@ import "package:ody_flutter/assets/images/images.dart";
 import "package:ody_flutter/components/ody_top_bar.dart";
 import "package:ody_flutter/screens/settings/model/notification_setting.dart";
 import "package:ody_flutter/screens/settings/model/use_of_service_setting.dart";
+import "package:webview_flutter/webview_flutter.dart";
 
 final List<NotificationSetting> notificationSettings =
     NotificationSetting.values.cast<NotificationSetting>();
@@ -20,107 +21,166 @@ class SettingsScreen extends StatefulWidget {
 }
 
 class _SettingsScreenState extends State<SettingsScreen> {
+  bool _showWebView = false;
+  late WebViewController _webViewController;
+
   @override
-  Widget build(final BuildContext context) => Scaffold(
+  void initState() {
+    super.initState();
+    _webViewController = WebViewController();
+  }
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
         backgroundColor: CommonColors.cream,
         body: SafeArea(
-          child: Column(
-            children: [
-              OdyTopBar(
-                title: "설정",
-                leftIcon: CommonImages.icArrowBack,
-                onLeftIcon: () {
-                  Navigator.pop(context);
-                },
-              ),
-              const SizedBox(height: 26),
-              Padding(
-                padding: const EdgeInsets.only(left: 30),
-                child: Align(
-                  alignment: Alignment.centerLeft,
-                  child: Text(
-                    "알림",
-                    style: PretendardFonts.bold18.copyWith(
-                      color: CommonColors.gray_600,
+          child: _showWebView
+              ? Scaffold(
+                  appBar: AppBar(
+                    leading: IconButton(
+                      icon: const Icon(Icons.arrow_back),
+                      onPressed: _handleWebViewBack,
                     ),
+                    backgroundColor: CommonColors.white,
                   ),
-                ),
-              ),
-              const SizedBox(height: 10),
-              for (var i = 0; i < notificationSettings.length; i++)
-                Container(
-                  margin: const EdgeInsets.only(top: 16, bottom: 16),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Row(
-                        children: [
-                          const SizedBox(width: 30),
-                          SvgPicture.asset(notificationSettings[i].icon),
-                          const SizedBox(width: 16),
-                          Text(
-                            notificationSettings[i].description,
-                            style: PretendardFonts.medium18.copyWith(
-                              color: CommonColors.gray_900,
-                            ),
-                          ),
-                        ],
-                      ),
-                      const Padding(
-                        padding: EdgeInsets.only(right: 30),
-                        child: SizedBox(
-                          width: 39,
-                          height: 24,
-                          child: Switch(
-                            value: false,
-                            onChanged: null,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              const SizedBox(height: 14),
-              const Divider(
-                color: CommonColors.gray_350,
-                thickness: 1,
-                height: 1,
-              ),
-              const SizedBox(height: 36),
-              Padding(
-                padding: const EdgeInsets.only(left: 30),
-                child: Align(
-                  alignment: Alignment.centerLeft,
-                  child: Text(
-                    "서비스 이용",
-                    style: PretendardFonts.bold18.copyWith(
-                      color: CommonColors.gray_600,
+                  body: WebViewWidget(controller: _webViewController),
+                )
+              : Column(
+                  children: [
+                    OdyTopBar(
+                      title: "설정",
+                      leftIcon: CommonImages.icArrowBack,
+                      onLeftIcon: () => Navigator.pop(context),
                     ),
-                  ),
+                    const SizedBox(height: 26),
+                    _buildNotificationSettings(),
+                    const SizedBox(height: 14),
+                    const Divider(
+                      color: CommonColors.gray_350,
+                      thickness: 1,
+                      height: 1,
+                    ),
+                    const SizedBox(height: 36),
+                    _buildServiceSettings(),
+                  ],
                 ),
-              ),
-              const SizedBox(height: 26),
-              for (var i = 0; i < useOfServiceSettings.length; i++)
-                Container(
-                  margin: const EdgeInsets.only(top: 16, bottom: 16),
-                  child: Row(
-                    children: [
-                      const SizedBox(width: 30),
-                      SvgPicture.asset(useOfServiceSettings[i].icon),
-                      const SizedBox(width: 16),
-                      GestureDetector(
-                        child: Text(
-                          useOfServiceSettings[i].description,
-                          style: PretendardFonts.medium18.copyWith(
-                            color: CommonColors.gray_900,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-            ],
-          ),
         ),
       );
+
+  Widget _buildNotificationSettings() => Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(left: 30),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                "알림",
+                style: PretendardFonts.bold18.copyWith(
+                  color: CommonColors.gray_600,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 10),
+          for (final setting in notificationSettings)
+            Container(
+              margin: const EdgeInsets.only(top: 16, bottom: 16),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Row(
+                    children: [
+                      const SizedBox(width: 30),
+                      SvgPicture.asset(setting.icon),
+                      const SizedBox(width: 16),
+                      Text(
+                        setting.description,
+                        style: PretendardFonts.medium18.copyWith(
+                          color: CommonColors.gray_900,
+                        ),
+                      ),
+                    ],
+                  ),
+                  const Padding(
+                    padding: EdgeInsets.only(right: 30),
+                    child: SizedBox(
+                      width: 39,
+                      height: 24,
+                      child: Switch(
+                        value: false,
+                        onChanged: null,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      );
+
+  Widget _buildServiceSettings() => Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(left: 30),
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: Text(
+                "서비스 이용",
+                style: PretendardFonts.bold18.copyWith(
+                  color: CommonColors.gray_600,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 26),
+          for (final setting in useOfServiceSettings)
+            Container(
+              margin: const EdgeInsets.only(top: 16, bottom: 16),
+              child: Row(
+                children: [
+                  const SizedBox(width: 30),
+                  SvgPicture.asset(setting.icon),
+                  const SizedBox(width: 16),
+                  GestureDetector(
+                    onTap: () async => _handleServiceItemTap(setting),
+                    child: Text(
+                      setting.description,
+                      style: PretendardFonts.medium18.copyWith(
+                        color: CommonColors.gray_900,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+        ],
+      );
+
+  Future<void> _handleServiceItemTap(UseOfServiceSetting setting) async {
+    _handleWebViewBack();
+    switch (setting.useOfServiceType) {
+      case UseOfServiceType.privacyPolicy:
+        await _webViewController.loadRequest(
+          Uri.parse(
+            "https://sly-face-106.notion.site/fecbe589eb23471ba2d0685cb3c2d274?pvs=4",
+          ),
+        );
+      case UseOfServiceType.term:
+        await _webViewController.loadRequest(
+          Uri.parse(
+            "https://sly-face-106.notion.site/beb204b6e6724ecbbb83496448fc7b53?pvs=4",
+          ),
+        );
+      case UseOfServiceType.logout:
+      case UseOfServiceType.withdraw:
+        // Handle logout or withdraw actions here
+        break;
+    }
+  }
+
+  void _handleWebViewBack() {
+    setState(() {
+      _showWebView = !_showWebView;
+    });
+  }
 }

--- a/ody_flutter/pubspec.yaml
+++ b/ody_flutter/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   path: ^1.9.0
   provider: ^6.1.2
   sqflite: ^2.4.1
+  webview_flutter: ^4.10.0
 
 dev_dependencies:
   flutter_lints: ^4.0.0


### PR DESCRIPTION
## PR 요약
- Closed: #62 

## 작업 내용
설정 화면에서 개인 정보 처리 방침, 서비스 이용 약관 노션 링크에 연결했습니다.
웹 뷰 위에 뒤로가기 버튼을 만들어 돌아갈 수 있게 만들었습니다.

## 참고 사항
없습니다.

## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|개인 정보 처리 방침|<img src="https://github.com/user-attachments/assets/05aeb955-4467-4e23-9ae7-061322d06e6e" width=300>|
|서비스 이용 약관|<img src="https://github.com/user-attachments/assets/6c89b502-2047-4e8d-86e8-5f9c397ea17d" width=300>|


