### PR TITLE
feat: 애플 회원탈퇴

### DIFF
--- a/ody_flutter/lib/components/ody_alert.dart
+++ b/ody_flutter/lib/components/ody_alert.dart
@@ -51,6 +51,7 @@ class OdyAlert extends StatelessWidget {
         width: 300,
         child: Text(
           title,
+          textAlign: TextAlign.center,
           style: PretendardFonts.bold24.copyWith(
             color: CommonColors.purple_800,
           ),
@@ -88,10 +89,7 @@ class OdyAlert extends StatelessWidget {
           ),
           Expanded(
             child: GestureDetector(
-              onTap: () {
-                onConfirm();
-                Navigator.pop(context);
-              },
+              onTap: onConfirm,
               child: Text(
                 confirmText,
                 style: PretendardFonts.medium18.copyWith(

--- a/ody_flutter/lib/data/db/service/auth_token_service.dart
+++ b/ody_flutter/lib/data/db/service/auth_token_service.dart
@@ -28,4 +28,9 @@ class AuthTokenService {
       return null;
     }
   }
+
+  Future<void> deleteToken() async {
+    final Database db = await _databaseHelper.database;
+    await db.delete("auth_token");
+  }
 }

--- a/ody_flutter/lib/data/network/base/base_service.dart
+++ b/ody_flutter/lib/data/network/base/base_service.dart
@@ -49,6 +49,22 @@ class BaseService {
     }
   }
 
+  Future<dynamic> deleteWithResponse({
+    required String path,
+    Map<String, dynamic>? headers,
+  }) async {
+    try {
+      final response = await _dio.delete(
+        path,
+        options: Options(headers: {...?headers}),
+      );
+      _printSuccessLog(response);
+      return response.data;
+    } on DioException catch (e) {
+      throw _handleError(e);
+    }
+  }
+
   Exception _handleError(DioException e) {
     _printErrorLog(e);
     switch (e.response?.statusCode) {

--- a/ody_flutter/lib/data/network/service/auth_service.dart
+++ b/ody_flutter/lib/data/network/service/auth_service.dart
@@ -18,4 +18,15 @@ class AuthService {
       rethrow;
     }
   }
+
+  Future<void> appleWithdrawal(Map<String, dynamic> headers) async {
+    try {
+      await baseService.deleteWithResponse(
+        path: "/v2/members",
+        headers: headers,
+      );
+    } catch(_) {
+      rethrow;
+    }
+  }
 }

--- a/ody_flutter/lib/data/repository/auth_repository_impl.dart
+++ b/ody_flutter/lib/data/repository/auth_repository_impl.dart
@@ -22,6 +22,20 @@ class AuthRepositoryImpl extends AuthRepository {
   }
 
   @override
+  Future<void> withdrawal() async {
+    try {
+      final token = await authTokenService.getToken();
+      final headers = {
+        "Authorization": "Bearer access-token=${token?.accessToken}",
+      };
+      await authService.appleWithdrawal(headers);
+      await authTokenService.deleteToken();
+    } catch (_) {
+      rethrow;
+    }
+  }
+
+  @override
   Future<int> saveToken(String accessToken, String refreshToken) async =>
       authTokenService.saveToken(
         AuthToken(

--- a/ody_flutter/lib/domain/repository/auth_repository.dart
+++ b/ody_flutter/lib/domain/repository/auth_repository.dart
@@ -4,6 +4,8 @@ import "package:ody_flutter/domain/model/auth_token.dart";
 abstract class AuthRepository {
   Future<AuthToken> login(AppleLogin request);
 
+  Future<void> withdrawal();
+
   Future<void> saveToken(String accessToken, String refreshToken);
 
   Future<AuthToken?> getToken();

--- a/ody_flutter/lib/screens/login/login_screen.dart
+++ b/ody_flutter/lib/screens/login/login_screen.dart
@@ -42,7 +42,7 @@ class _LoginScreenState extends State<LoginScreen> {
     final action = _viewModel.navigation.value;
     if (action != null) {
       if (action is NavigateToGatherings) {
-        await Navigator.pushNamed(context, Routes.gatherings);
+        await Navigator.pushReplacementNamed(context, Routes.gatherings);
       }
       // 다른 액션에 대한 처리도 추가 가능
     }

--- a/ody_flutter/lib/screens/settings/settings_navigate_action.dart
+++ b/ody_flutter/lib/screens/settings/settings_navigate_action.dart
@@ -1,0 +1,3 @@
+sealed class SettingsNavigateAction {}
+
+class NavigateToLogin extends SettingsNavigateAction {}

--- a/ody_flutter/lib/screens/settings/settings_view_model.dart
+++ b/ody_flutter/lib/screens/settings/settings_view_model.dart
@@ -1,0 +1,15 @@
+import "package:flutter/cupertino.dart";
+import "package:ody_flutter/domain/repository/auth_repository.dart";
+import "package:ody_flutter/screens/settings/settings_navigate_action.dart";
+
+class SettingViewModel extends ChangeNotifier {
+  SettingViewModel(this._authRepository);
+
+  final AuthRepository _authRepository;
+  ValueNotifier<SettingsNavigateAction?> navigation = ValueNotifier(null);
+
+  Future appleWithdrawal() async {
+    await _authRepository.withdrawal();
+    navigation.value = NavigateToLogin();
+  }
+}


### PR DESCRIPTION
## PR 요약
- Closed: #60 

## 작업 내용
애플 회원탈퇴 api 연결 및 액세스 토큰, 리프레쉬 토큰 내부 디비에서 삭제하고 회원탈퇴시 로그인 화면으로 이동하게 구현했습니다.

## 참고 사항
추가적으로 로그인 해서 들어가면 로그인 화면은 스택에서 없어지게 했습니다.

<!-- ## 📸 스크린샷
|기능|스크린샷|
|:--:|:--:|
|기능이름|스크린샷 첨부| -->
