### PR TITLE
feat: 방 개설 화면 구현 완료 (w. 카카오 장소 검색 API)

### DIFF
--- a/ody_flutter/analysis_options.yaml
+++ b/ody_flutter/analysis_options.yaml
@@ -103,7 +103,7 @@ linter:
     - noop_primitive_operations
     - null_check_on_nullable_type_parameter
     - null_closures
-    - one_member_abstracts
+    # - one_member_abstracts
     - only_throw_errors
     - overridden_fields
     - package_names

--- a/ody_flutter/lib/components/ody_text_field.dart
+++ b/ody_flutter/lib/components/ody_text_field.dart
@@ -47,7 +47,7 @@ class _OdyTextFieldState extends State<OdyTextField> {
                 controller: _textFieldController,
                 decoration: InputDecoration(
                   hintText: widget.placeHolder,
-                  hintStyle: PretendardFonts.medium20.copyWith(
+                  hintStyle: PretendardFonts.medium18.copyWith(
                     color: CommonColors.gray_350,
                   ),
                   enabledBorder: _inputBorder(),

--- a/ody_flutter/lib/data/entity/gathering/location_response.dart
+++ b/ody_flutter/lib/data/entity/gathering/location_response.dart
@@ -5,7 +5,8 @@ class LocationResponse {
       LocationResponse(
         (json["documents"] as List<dynamic>?)
             ?.map(
-                (e) => LocationResponseData.fromJson(e as Map<String, dynamic>))
+              (e) => LocationResponseData.fromJson(e as Map<String, dynamic>),
+            )
             .toList(),
       );
 

--- a/ody_flutter/lib/data/entity/gathering/location_response.dart
+++ b/ody_flutter/lib/data/entity/gathering/location_response.dart
@@ -1,0 +1,34 @@
+class LocationResponse {
+  LocationResponse(this.documents);
+
+  factory LocationResponse.fromJson(Map<String, dynamic> json) =>
+      LocationResponse(
+        (json["documents"] as List<dynamic>?)
+            ?.map(
+                (e) => LocationResponseData.fromJson(e as Map<String, dynamic>))
+            .toList(),
+      );
+
+  List<LocationResponseData>? documents;
+}
+
+class LocationResponseData {
+  LocationResponseData(
+    this.placeName,
+    this.roadAddressName,
+    this.x,
+    this.y,
+  );
+  factory LocationResponseData.fromJson(Map<String, dynamic> json) =>
+      LocationResponseData(
+        json["place_name"],
+        json["road_address_name"],
+        json["x"],
+        json["y"],
+      );
+
+  String? placeName;
+  String? roadAddressName;
+  String? x;
+  String? y;
+}

--- a/ody_flutter/lib/data/entity/mapper/location_mapper.dart
+++ b/ody_flutter/lib/data/entity/mapper/location_mapper.dart
@@ -1,0 +1,17 @@
+import "package:ody_flutter/data/entity/gathering/location_response.dart";
+import "package:ody_flutter/domain/model/location.dart";
+
+extension ToDomain on LocationResponse {
+  List<LocationModel> toModel() =>
+      documents
+          ?.map(
+            (document) => LocationModel(
+              name: document.placeName,
+              address: document.roadAddressName,
+              latitude: double.parse(document.y ?? "0"),
+              longitude: double.parse(document.x ?? "0"),
+            ),
+          )
+          .toList() ??
+      [];
+}

--- a/ody_flutter/lib/data/network/base/base_service.dart
+++ b/ody_flutter/lib/data/network/base/base_service.dart
@@ -34,12 +34,13 @@ class BaseService {
   }
 
   Future<dynamic> getWithResponse({
-    required String path,
+    String? url,
+    String? path,
     Map<String, dynamic>? headers,
   }) async {
     try {
-      final response = await _dio.get(
-        path,
+      final response = await _dio.getUri(
+        Uri.parse(url ?? _dio.options.baseUrl + (path ?? "")),
         options: Options(headers: {...?headers}),
       );
       _printSuccessLog(response);

--- a/ody_flutter/lib/data/network/service/gathering_service_impl.dart
+++ b/ody_flutter/lib/data/network/service/gathering_service_impl.dart
@@ -1,19 +1,22 @@
+import "package:ody_flutter/data/db/service/auth_token_service.dart";
 import "package:ody_flutter/data/entity/gathering/gathering_request.dart";
 import "package:ody_flutter/data/entity/gathering/gathering_response.dart";
 import "package:ody_flutter/data/entity/gathering/gatherings_response.dart";
 import "package:ody_flutter/data/network/base/base_service.dart";
 
 class GatheringService {
-  GatheringService(this.baseService);
+  GatheringService(this.baseService, this.authTokenService);
 
   final BaseService baseService;
+  final AuthTokenService authTokenService;
 
   Future<GatheringResponse> createGathering(GatheringRequest request) async {
     try {
+      final token = await authTokenService.getToken();
       final response = await baseService.postWithResponse(
         path: "/v1/meetings",
         data: request.toJson(),
-        headers: {"Authorization": "Bearer access-token={access-token}"},
+        headers: {"Authorization": "Bearer access-token=${token?.accessToken}"},
       );
       return GatheringResponse.fromJson(response);
     } catch (_) {

--- a/ody_flutter/lib/data/network/service/location_service.dart
+++ b/ody_flutter/lib/data/network/service/location_service.dart
@@ -1,0 +1,22 @@
+import "package:flutter_dotenv/flutter_dotenv.dart";
+import "package:ody_flutter/data/entity/gathering/location_response.dart";
+import "package:ody_flutter/data/network/base/base_service.dart";
+
+class LocationService {
+  LocationService(this.baseService);
+
+  final BaseService baseService;
+
+  Future<LocationResponse> fetchLocation(String keyword) async {
+    try {
+      final response = await baseService.getWithResponse(
+        url:
+            "https://dapi.kakao.com/v2/local/search/keyword.json?query=$keyword&page=1&size=15",
+        headers: {"Authorization": "KakaoAK ${dotenv.get("KAKAO_API_KEY")}"},
+      );
+      return LocationResponse.fromJson(response);
+    } catch (_) {
+      rethrow;
+    }
+  }
+}

--- a/ody_flutter/lib/data/repository/location_repository_impl.dart
+++ b/ody_flutter/lib/data/repository/location_repository_impl.dart
@@ -1,0 +1,20 @@
+import "package:ody_flutter/data/entity/mapper/location_mapper.dart";
+import "package:ody_flutter/data/network/service/location_service.dart";
+import "package:ody_flutter/domain/model/location.dart";
+import "package:ody_flutter/domain/repository/location_repository.dart";
+
+class LocationRepositoryImpl implements LocationRepository {
+  LocationRepositoryImpl(this.locationService);
+
+  final LocationService locationService;
+
+  @override
+  Future<List<LocationModel>> searchLocation(String keyword) async {
+    try {
+      final response = await locationService.fetchLocation(keyword);
+      return response.toModel();
+    } catch (_) {
+      rethrow;
+    }
+  }
+}

--- a/ody_flutter/lib/domain/model/location.dart
+++ b/ody_flutter/lib/domain/model/location.dart
@@ -1,0 +1,20 @@
+class LocationModel {
+  LocationModel({
+    required this.name,
+    required this.address,
+    required this.longitude,
+    required this.latitude,
+  });
+
+  factory LocationModel.init() => LocationModel(
+        name: null,
+        address: null,
+        longitude: null,
+        latitude: null,
+      );
+
+  final String? name;
+  final String? address;
+  final double? longitude;
+  final double? latitude;
+}

--- a/ody_flutter/lib/domain/repository/location_repository.dart
+++ b/ody_flutter/lib/domain/repository/location_repository.dart
@@ -1,0 +1,5 @@
+import "package:ody_flutter/domain/model/location.dart";
+
+abstract class LocationRepository {
+  Future<List<LocationModel>> searchLocation(String keyword);
+}

--- a/ody_flutter/lib/screens/gathering_creator/gathering_creator_screen.dart
+++ b/ody_flutter/lib/screens/gathering_creator/gathering_creator_screen.dart
@@ -21,7 +21,7 @@ class GatheringCreatorScreen extends StatelessWidget {
   // to do: 추후에 주입 필요
   final _viewModel = GatheringCreatorViewModel(
     GatheringRepositoryImpl(
-      GatheringService(BaseService()),
+      GatheringService(BaseService(), AuthTokenService()),
       AuthTokenService(),
     ),
   );
@@ -29,88 +29,91 @@ class GatheringCreatorScreen extends StatelessWidget {
   @override
   Widget build(final BuildContext context) => ListenableBuilder(
         listenable: _viewModel,
-        builder: (BuildContext context, Widget? child) => Scaffold(
-          backgroundColor: CommonColors.cream,
-          body: SafeArea(
-            child: ColoredBox(
-              color: CommonColors.cream,
-              child: Column(
-                children: [
-                  OdyTopBar(
-                    title: "",
-                    leftIcon: CommonImages.icArrowBack,
-                    onLeftIcon: () async {
-                      if (_viewModel.currentScreenType ==
-                          GatheringCreatorScreenType.title) {
-                        Navigator.pop(context);
-                      } else {
-                        await _viewModel.goToPreviousPage();
-                      }
-                    },
-                  ),
-                  const SizedBox(
-                    height: 50,
-                  ),
-                  SmoothPageIndicator(
-                    controller: _viewModel.pageController,
-                    count: 4,
-                    effect: const WormEffect(
-                      dotColor: CommonColors.gray_300,
-                      activeDotColor: CommonColors.purple_800,
-                      dotWidth: 10,
-                      dotHeight: 10,
-                    ),
-                  ),
-                  const SizedBox(
-                    height: 52,
-                  ),
-                  Expanded(
-                    child: PageView(
-                      controller: _viewModel.pageController,
-                      physics: _viewModel.isGoingPrevious
-                          ? const AlwaysScrollableScrollPhysics()
-                          : _viewModel.isConfirmEnabled.value
-                              ? const AlwaysScrollableScrollPhysics()
-                              : const NeverScrollableScrollPhysics(),
-                      children: [
-                        GatheringTitleScreen(
-                          viewModel: _viewModel,
-                        ),
-                        GatheringDateScreen(
-                          viewModel: _viewModel,
-                        ),
-                        GatheringTimeScreen(
-                          viewModel: _viewModel,
-                        ),
-                        GatheringLocationScreen(
-                          viewModel: _viewModel,
-                        ),
-                      ],
-                    ),
-                  ),
-                  OdyButton(
-                    buttonType: OdyButtonType.next,
-                    onPressed: () async {
-                      if (_viewModel.currentScreenType ==
-                          GatheringCreatorScreenType.location) {
-                        await _viewModel.createGathering();
-                        if (context.mounted) {
-                          await Navigator.pushNamed(
-                            context,
-                            Routes.gatheringEnter,
-                          );
+        builder: (BuildContext context, Widget? child) => GestureDetector(
+          onTap: () => FocusScope.of(context).unfocus(),
+          child: Scaffold(
+            backgroundColor: CommonColors.cream,
+            body: SafeArea(
+              child: ColoredBox(
+                color: CommonColors.cream,
+                child: Column(
+                  children: [
+                    OdyTopBar(
+                      title: "",
+                      leftIcon: CommonImages.icArrowBack,
+                      onLeftIcon: () async {
+                        if (_viewModel.currentScreenType ==
+                            GatheringCreatorScreenType.title) {
+                          Navigator.pop(context);
+                        } else {
+                          await _viewModel.goToPreviousPage();
                         }
-                        return;
-                      }
+                      },
+                    ),
+                    const SizedBox(
+                      height: 50,
+                    ),
+                    SmoothPageIndicator(
+                      controller: _viewModel.pageController,
+                      count: 4,
+                      effect: const WormEffect(
+                        dotColor: CommonColors.gray_300,
+                        activeDotColor: CommonColors.purple_800,
+                        dotWidth: 10,
+                        dotHeight: 10,
+                      ),
+                    ),
+                    const SizedBox(
+                      height: 52,
+                    ),
+                    Expanded(
+                      child: PageView(
+                        controller: _viewModel.pageController,
+                        physics: _viewModel.isGoingPrevious
+                            ? const AlwaysScrollableScrollPhysics()
+                            : _viewModel.isConfirmEnabled.value
+                                ? const AlwaysScrollableScrollPhysics()
+                                : const NeverScrollableScrollPhysics(),
+                        children: [
+                          GatheringTitleScreen(
+                            viewModel: _viewModel,
+                          ),
+                          GatheringDateScreen(
+                            viewModel: _viewModel,
+                          ),
+                          GatheringTimeScreen(
+                            viewModel: _viewModel,
+                          ),
+                          GatheringLocationScreen(
+                            viewModel: _viewModel,
+                          ),
+                        ],
+                      ),
+                    ),
+                    OdyButton(
+                      buttonType: OdyButtonType.next,
+                      onPressed: () async {
+                        if (_viewModel.currentScreenType ==
+                            GatheringCreatorScreenType.location) {
+                          await _viewModel.createGathering();
+                          if (context.mounted) {
+                            await Navigator.pushNamed(
+                              context,
+                              Routes.gatheringEnter,
+                            );
+                          }
+                          return;
+                        }
 
-                      await _viewModel.goToNextPage();
-                    },
-                    isEnabled: _viewModel.isConfirmEnabled,
-                  ),
-                  const SizedBox(
-                    height: 10,
-                  ),
-                ],
+                        await _viewModel.goToNextPage();
+                      },
+                      isEnabled: _viewModel.isConfirmEnabled,
+                    ),
+                    const SizedBox(
+                      height: 10,
+                    ),
+                  ],
+                ),
               ),
             ),
           ),

--- a/ody_flutter/lib/screens/gathering_creator/gathering_creator_view_model.dart
+++ b/ody_flutter/lib/screens/gathering_creator/gathering_creator_view_model.dart
@@ -1,6 +1,7 @@
 import "package:flutter/cupertino.dart";
 import "package:ody_flutter/data/entity/gathering/gathering_request.dart";
 import "package:ody_flutter/domain/model/gathering.dart";
+import "package:ody_flutter/domain/model/location.dart";
 import "package:ody_flutter/domain/repository/gathering_repository.dart";
 
 enum GatheringCreatorScreenType {
@@ -36,8 +37,7 @@ class GatheringCreatorViewModel extends ChangeNotifier {
   final ValueNotifier<String> locationText = ValueNotifier("");
   final ValueNotifier<bool> isConfirmEnabled = ValueNotifier(false);
 
-  String targetLatitude = "";
-  String targetLongitude = "";
+  LocationModel location = LocationModel.init();
   bool isGoingPrevious = false;
 
   GatheringCreatorScreenType _currentScreenType =
@@ -104,21 +104,9 @@ class GatheringCreatorViewModel extends ChangeNotifier {
       date: _dateToString(),
       time: _timeToString(),
       targetAddress: locationText.value,
-      targetLatitude: targetLatitude,
-      targetLongitude: targetLongitude,
+      targetLatitude: "${location.latitude}",
+      targetLongitude: "${location.longitude}",
     );
-
-    debugPrint("""
-=== [CreateGathering] =========================================
-🚀 Request Info:
-  • name: ${request.name}
-  • date: ${request.date}
-  • time: ${request.time}
-  • address: ${request.targetAddress}
-  • latitude: ${request.targetLatitude}
-  • longitude: ${request.targetLongitude}
-============================================================
-""");
 
     gathering = await _gatheringRepository.createGathering(request);
   }

--- a/ody_flutter/lib/screens/gathering_creator/model/location.dart
+++ b/ody_flutter/lib/screens/gathering_creator/model/location.dart
@@ -1,9 +1,0 @@
-class Location {
-  Location({
-    this.title,
-    this.address,
-  });
-
-  final String? title;
-  final String? address;
-}

--- a/ody_flutter/lib/screens/gathering_creator/screens/gathering_location_screen.dart
+++ b/ody_flutter/lib/screens/gathering_creator/screens/gathering_location_screen.dart
@@ -4,8 +4,8 @@ import "package:ody_flutter/assets/fonts/pretendard_fonts.dart";
 import "package:ody_flutter/components/ody_highlight_text.dart";
 import "package:ody_flutter/components/ody_text_field.dart";
 import "package:ody_flutter/config/routes.dart";
+import "package:ody_flutter/domain/model/location.dart";
 import "package:ody_flutter/screens/gathering_creator/gathering_creator_view_model.dart";
-import "package:ody_flutter/screens/gathering_creator/model/location.dart";
 
 class GatheringLocationScreen extends StatelessWidget {
   const GatheringLocationScreen({required this.viewModel, super.key});
@@ -45,12 +45,15 @@ class GatheringLocationScreen extends StatelessWidget {
                     final result = await Navigator.pushNamed(
                       context,
                       Routes.gatheringLocationSearch,
-                      arguments: Location(),
+                      arguments: LocationModel,
                     );
 
                     if (result != null) {
                       viewModel.locationText.value =
-                          (result as Location).address ?? "";
+                          (result as LocationModel).address ??
+                              result.name ??
+                              "";
+                      viewModel.location = (result as LocationModel);
                       viewModel.isConfirmEnabled.value = true;
                     }
                   },

--- a/ody_flutter/lib/screens/gathering_creator/screens/gathering_location_screen.dart
+++ b/ody_flutter/lib/screens/gathering_creator/screens/gathering_location_screen.dart
@@ -53,7 +53,7 @@ class GatheringLocationScreen extends StatelessWidget {
                           (result as LocationModel).address ??
                               result.name ??
                               "";
-                      viewModel.location = (result as LocationModel);
+                      viewModel.location = result;
                       viewModel.isConfirmEnabled.value = true;
                     }
                   },

--- a/ody_flutter/lib/screens/gathering_creator/screens/gathering_location_search_screen.dart
+++ b/ody_flutter/lib/screens/gathering_creator/screens/gathering_location_search_screen.dart
@@ -5,65 +5,76 @@ import "package:ody_flutter/assets/fonts/pretendard_fonts.dart";
 import "package:ody_flutter/assets/images/images.dart";
 import "package:ody_flutter/components/ody_text_field.dart";
 import "package:ody_flutter/components/ody_top_bar.dart";
-import "package:ody_flutter/screens/gathering_creator/model/location.dart";
+import "package:ody_flutter/data/network/base/base_service.dart";
+import "package:ody_flutter/data/network/service/location_service.dart";
+import "package:ody_flutter/data/repository/location_repository_impl.dart";
+import "package:ody_flutter/domain/model/location.dart";
+import "package:ody_flutter/screens/gathering_creator/screens/gathering_location_view_model.dart";
 
 class GatheringLocationSearchScreen extends StatelessWidget {
   GatheringLocationSearchScreen({super.key});
 
-  final ValueNotifier<String> text = ValueNotifier("");
-
-  final List<Location> locations = [
-    Location(
-      title: "사당역 2호선",
-      address: "서울 동작구 남부순환로 208",
-    ),
-    Location(
-      title: "사당역 4호선",
-      address: "서울 동작구 동작대로 3 사당역",
-    ),
-  ];
+  final GatheringLocationViewModel _viewModel = GatheringLocationViewModel(
+    LocationRepositoryImpl(LocationService(BaseService())),
+  );
 
   @override
-  Widget build(BuildContext context) => Scaffold(
-        backgroundColor: CommonColors.cream,
-        body: SafeArea(
-          child: Column(
-            children: [
-              OdyTopBar(
-                title: "장소 찾기",
-                leftIcon: CommonImages.icArrowBack,
-                onLeftIcon: () => Navigator.pop(context),
+  Widget build(BuildContext context) => ListenableBuilder(
+        listenable: _viewModel,
+        builder: (BuildContext context, Widget? child) => GestureDetector(
+          onTap: () => FocusScope.of(context).unfocus(),
+          child: Scaffold(
+            backgroundColor: CommonColors.cream,
+            body: SafeArea(
+              child: Column(
+                children: [
+                  OdyTopBar(
+                    title: "장소 찾기",
+                    leftIcon: CommonImages.icArrowBack,
+                    onLeftIcon: () => Navigator.pop(context),
+                  ),
+                  const SizedBox(
+                    height: 36,
+                  ),
+                  OdyTextField(
+                    textFieldType: OdyTextFieldType.clearButton,
+                    placeHolder: "주소나 상호명을 검색해 보세요",
+                    text: _viewModel.text,
+                  ),
+                  const SizedBox(
+                    height: 32,
+                  ),
+                  Container(
+                    color: CommonColors.gray_300,
+                    height: 3,
+                  ),
+                  Expanded(
+                    child: _viewModel.locationList.isEmpty
+                        ? _emptyView()
+                        : _locationListView(context),
+                  ),
+                ],
               ),
-              const SizedBox(
-                height: 36,
-              ),
-              OdyTextField(
-                textFieldType: OdyTextFieldType.clearButton,
-                placeHolder: "주소나 상호명을 검색해 보세요",
-                text: text,
-              ),
-              const SizedBox(
-                height: 32,
-              ),
-              Container(
-                color: CommonColors.gray_300,
-                height: 3,
-              ),
-              Expanded(
-                child: _locationListView(
-                  context,
-                ),
-              ),
-            ],
+            ),
           ),
         ),
       );
 
+  Widget _emptyView() => Center(
+        child: Text(
+          "검색 결과가\n 존재하지 않아요.",
+          style: PretendardFonts.medium18.copyWith(
+            color: CommonColors.gray_350,
+          ),
+          textAlign: TextAlign.center,
+        ),
+      );
+
   Widget _locationListView(BuildContext context) => ListView.separated(
-        itemCount: locations.length,
+        itemCount: _viewModel.locationList.length,
         itemBuilder: (context, index) => _locationView(
-          () => Navigator.pop(context, locations[index]),
-          locations[index],
+          () => Navigator.pop(context, _viewModel.locationList[index]),
+          _viewModel.locationList[index],
         ),
         separatorBuilder: (BuildContext context, int index) => Container(
           color: CommonColors.gray_350,
@@ -71,7 +82,8 @@ class GatheringLocationSearchScreen extends StatelessWidget {
         ),
       );
 
-  Widget _locationView(Function() onTap, Location location) => GestureDetector(
+  Widget _locationView(Function() onTap, LocationModel location) =>
+      GestureDetector(
         onTap: () => onTap(),
         child: SizedBox(
           height: 84,
@@ -86,7 +98,7 @@ class GatheringLocationSearchScreen extends StatelessWidget {
                 top: 22,
                 left: 54,
                 child: Text(
-                  location.title ?? "",
+                  location.name ?? "",
                   style: PretendardFonts.bold16.copyWith(
                     color: CommonColors.purple_800,
                   ),

--- a/ody_flutter/lib/screens/gathering_creator/screens/gathering_location_view_model.dart
+++ b/ody_flutter/lib/screens/gathering_creator/screens/gathering_location_view_model.dart
@@ -1,0 +1,40 @@
+import "dart:async";
+
+import "package:flutter/cupertino.dart";
+import "package:ody_flutter/domain/model/location.dart";
+import "package:ody_flutter/domain/repository/location_repository.dart";
+
+class GatheringLocationViewModel extends ChangeNotifier {
+  GatheringLocationViewModel(this.locationRepository) {
+    _init();
+  }
+
+  final LocationRepository locationRepository;
+
+  final ValueNotifier<String> text = ValueNotifier("");
+
+  List<LocationModel> locationList = [];
+
+  Timer _debounceTimer = Timer(Duration.zero, () {});
+
+  void _init() {
+    text.addListener(() async {
+      await _searchLocation(text.value);
+    });
+  }
+
+  Future<void> _searchLocation(String keyword) async {
+    if (_debounceTimer.isActive) {
+      _debounceTimer.cancel();
+    }
+
+    _debounceTimer = Timer(const Duration(milliseconds: 500), () async {
+      if (keyword.isNotEmpty) {
+        locationList = await locationRepository.searchLocation(keyword);
+      } else {
+        locationList = [];
+      }
+      notifyListeners();
+    });
+  }
+}

--- a/ody_flutter/lib/screens/gathering_enter/gathering_enter_location_screen.dart
+++ b/ody_flutter/lib/screens/gathering_enter/gathering_enter_location_screen.dart
@@ -8,7 +8,7 @@ import "package:ody_flutter/components/ody_highlight_text.dart";
 import "package:ody_flutter/components/ody_text_field.dart";
 import "package:ody_flutter/components/ody_top_bar.dart";
 import "package:ody_flutter/config/routes.dart";
-import "package:ody_flutter/screens/gathering_creator/model/location.dart";
+import "package:ody_flutter/domain/model/location.dart";
 import "package:ody_flutter/screens/gathering_enter/gathering_enter_view_model.dart";
 
 class GatheringEnterScreen extends StatelessWidget {
@@ -80,12 +80,12 @@ class GatheringEnterScreen extends StatelessWidget {
                       final result = await Navigator.pushNamed(
                         context,
                         Routes.gatheringLocationSearch,
-                        arguments: Location(),
+                        arguments: LocationModel,
                       );
 
                       if (result != null) {
                         viewModel.locationText.value =
-                            (result as Location).address ?? "";
+                            (result as LocationModel).address ?? "";
                         viewModel.isConfirmEnabled.value = true;
                       }
                     },

--- a/ody_flutter/lib/screens/gatherings/gatherings_screen.dart
+++ b/ody_flutter/lib/screens/gatherings/gatherings_screen.dart
@@ -32,7 +32,7 @@ class _GatheringsScreenState extends State<GatheringsScreen> {
     super.initState();
     _viewModel = GatheringsViewModel(
       GatheringRepositoryImpl(
-        GatheringService(BaseService()),
+        GatheringService(BaseService(), AuthTokenService()),
         AuthTokenService(),
       ),
     );


### PR DESCRIPTION
## PR 요약
- Closed: #74 

## 작업 내용
#### 카카오 장소 검색 API 연동
- .env 파일에 KAKAO_API_KEY 추가 필요합니다 !
- 무한 스크롤은 이후에 추가할게요..

#### 방 개설 API 연동
v1/meetings 연동했고 아래와 같이 전송됩니다.
```
• Data: {
 "name": "오디 첫 약속",
 "date": "2025-06-06",
 "time": "06:00",
 "targetAddress": "서울 종로구 사직로 161",
 "targetLatitude": "37.577613288258206",
  "targetLongitude": "126.97689786832184"
 }
```
- 계속 401 에러가 나는데 auth token쪽 확인 좀 부탁드립니다 ㅎ
- 현재 AuthTokenService 가지고 getToken() 통해서 accessToken 주입중인데 이후 전역적으로 사용할 수 있는 방법으로 바꾸면 좋을 것 같아요 ~!

## 참고 사항
없습니다.

## 📸 스크린샷
|장소 검색|
|:--:|
|<img src="https://github.com/user-attachments/assets/4c7b4e56-9afe-4ed8-b287-1d8e7957188b" width="280" />|

